### PR TITLE
Ecosystem -> Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](.gitbook/assets/OpenDEX.png)
 
-**OpenDEX is a cross-chain decentralized exchange network, featuring a user-friendly web app for spontaneous asset swaps and a layer 3 high-speed trading network for liquidity providers & day traders built on the [Lightning](https://lightning.network/) and [Connext](https://connext.network/) networks.** OpenDEX consists of software, community, member projects, and the BOLD protocol standard with the goal to unify currently incompatible protocols and fragmented liquidity.
+**OpenDEX is a cross-chain DEX network, featuring a user-friendly web app for spontaneous asset swaps and a layer 3 high-speed trading network for liquidity providers & day traders built on the [Lightning](https://lightning.network/) and [Connext](https://connext.network/) networks.** OpenDEX consists of software, community, member projects, and the BOLD protocol standard with the goal to unify currently incompatible protocols and fragmented liquidity.
 
 ## Get Started
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](.gitbook/assets/OpenDEX.png)
 
-**OpenDEX is a cross-chain DEX ecosystem, featuring a user-friendly web app for spontaneous asset swaps and a layer 3 high-speed trading network for liquidity providers & day traders built on the [Lightning](https://lightning.network/) and [Connext](https://connext.network/) networks.** OpenDEX consists of software, community, member projects, and the BOLD protocol standard with the goal to unify currently incompatible protocols and fragmented liquidity.
+**OpenDEX is a cross-chain decentralized exchange network, featuring a user-friendly web app for spontaneous asset swaps and a layer 3 high-speed trading network for liquidity providers & day traders built on the [Lightning](https://lightning.network/) and [Connext](https://connext.network/) networks.** OpenDEX consists of software, community, member projects, and the BOLD protocol standard with the goal to unify currently incompatible protocols and fragmented liquidity.
 
 ## Get Started
 


### PR DESCRIPTION
Sorry - one more.

Reason why change ecosystem -> network: we should consistently use the same terms to describe the same thing and it's "network" in all other places. Especially this first sentence on the landing page is important since it'll show in google's "What is OpenDEX" definition snippet.